### PR TITLE
Detect bad record read on RGLngStr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*.BAK
+*.$$$
+*.swp
+*.iml
+*.DSK
+.idea
+.DS_Store
+OUT/

--- a/SOURCE/COMMON.PAS
+++ b/SOURCE/COMMON.PAS
@@ -1230,6 +1230,7 @@ VAR
   RGStrFile: FILE;
   S: STRING;
   TotLoad: LongInt;
+  Res: Word; { Result of loading a block, used for checking string exists. }
 BEGIN
   Assign(StrPointerFile,General.TextPath+'RGLNGPR.DAT');
   Reset(StrPointerFile);
@@ -1240,10 +1241,35 @@ BEGIN
   TotLoad := 0;
   Assign(RGStrFile,General.TextPath+'RGLNGTX.DAT');
   Reset(RGStrFile,1);
+
+  IF StrPointer.Pointer-1 >= FileSize(RGStrFile) THEN
+  BEGIN
+       Writeln('Detected bad RGLNG string ', StrNum);
+       Writeln('Attempted to read ', StrPointer.Pointer-1,
+               ' for file of size ', FileSize(RGStrFile));
+       Halt(1);
+  END;
+
   Seek(RGStrFile,(StrPointer.Pointer - 1));
   REPEAT
-    BlockRead(RGStrFile,S[0],1);
-    BlockRead(RGStrFile,S[1],Ord(S[0]));
+    BlockRead(RGStrFile,S[0],1, Res);
+    { Find out if we read the expected number of records }
+    IF Res <> 1 THEN
+    BEGIN
+       Writeln('Unable to read RGLngStr #', StrNum, ' Bad # of records');
+       Halt(1);
+    END;
+
+    BlockRead(RGStrFile,S[1],Ord(S[0]), Res);
+
+    { Check expected read number of records again }
+    IF Res <> Ord(S[0]) THEN
+    BEGIN
+       Writeln('Unable to read records for RGLngStr #', StrNum);
+       Delay(1000);
+       Halt(1);
+    END;
+
     Inc(TotLoad,(Length(S) + 1));
     { -- }
     CASE StrNum OF


### PR DESCRIPTION
Nearly two years later I come back with some code to deal with this: https://github.com/leewoodridge/RenegadeBBS/issues/3

Please note: I don't think `HALT`ing on these errors might be the best idea, nor Writeln the error either.  I was thinking, instead, I could write to a log file? Or, possibly, return a STRING that is a placeholder if the reading the expected thing is an error? Something like "<<BAD STRNUM #123>" ?  Let me know what you think.

I also have some ideas to catch this at the RGLNG.EXE stage but will code those later.

Here is what happens on the latest if it's looking for a string that is not present in a possibly outdated RGLNG file. 
![stuck-thing](https://github.com/user-attachments/assets/a17499b1-30f1-45fc-aa09-7631aedf6cec)

Here is what happens with this update:
![error-detect](https://github.com/user-attachments/assets/fe1db3a6-ca1a-4f3a-9620-48e48c16e830)

The output is something like
```
Detected bad RGLNG string 282
Attempted to read 1386031 for file of size 13466
```


---

Added the following checks to lRGLngStr to detect if we're reading from a potentially outdated or bad RGLNG.TXT file (after compiling).

* Is the pointer we're seeking to is past the end of file.
* Did we read 1 record for the strnum?
* Did we read all expected records for the str?